### PR TITLE
[Refactoring] DMNMarshaller

### DIFF
--- a/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-backend/src/test/java/org/kie/workbench/common/dmn/backend/DMNMarshallerTest.java
@@ -70,11 +70,9 @@ import org.kie.dmn.api.core.ast.BusinessKnowledgeModelNode;
 import org.kie.dmn.backend.marshalling.v1x.DMNMarshallerFactory;
 import org.kie.dmn.core.util.DMNRuntimeUtil;
 import org.kie.dmn.core.util.KieHelper;
-import org.kie.dmn.model.api.DRGElement;
 import org.kie.dmn.model.api.DecisionTable;
 import org.kie.dmn.model.api.Definitions;
 import org.kie.dmn.model.api.FunctionKind;
-import org.kie.dmn.model.api.Import;
 import org.kie.dmn.model.api.dmndi.Bounds;
 import org.kie.dmn.model.api.dmndi.Color;
 import org.kie.dmn.model.api.dmndi.DMNEdge;
@@ -1824,22 +1822,33 @@ public class DMNMarshallerTest {
     }
 
     @Test
-    public void testGetImportedDRGElements() {
+    public void testGetImportedDrgElementsByShape() {
+        // TODO
+    }
 
-        final Metadata metadata = mock(Metadata.class);
-        final org.kie.dmn.model.api.Definitions dmnXml = mock(org.kie.dmn.model.api.Definitions.class);
-        final List<Import> imports = asList(mock(Import.class), mock(Import.class));
-        final DMNMarshaller marshaller = getDMNMarshaller();
-        final List<DRGElement> expectedDRGElements = asList(mock(DRGElement.class), mock(DRGElement.class), mock(DRGElement.class));
-        final Map<Import, Definitions> definitions = mock(Map.class);
+    @Test
+    public void testGetDmnElementRef() {
+        // TODO
+    }
 
-        when(dmnXml.getImport()).thenReturn(imports);
-        when(dmnMarshallerImportsHelper.getImportDefinitions(metadata, imports)).thenReturn(definitions);
-        when(dmnMarshallerImportsHelper.getImportedDRGElements(definitions)).thenReturn(expectedDRGElements);
+    @Test
+    public void testGetUniqueDMNShapes() {
+        // TODO
+    }
 
-        final List<DRGElement> actualDRGElements = marshaller.getImportedDRGElements(metadata, dmnXml);
+    @Test
+    public void testSetAllowOnlyVisualChange() {
+        // TODO
+    }
 
-        assertEquals(expectedDRGElements, actualDRGElements);
+    @Test
+    public void testIsImportedDRGElementWithDmnDRGElement() {
+        // TODO
+    }
+
+    @Test
+    public void testIsImportedDRGElementWithWbDRGElement() {
+        // TODO
     }
 
     @SuppressWarnings("unchecked")

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditBusinessKnowledgeModelToolboxAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditBusinessKnowledgeModelToolboxAction.java
@@ -81,7 +81,7 @@ public class DMNEditBusinessKnowledgeModelToolboxAction implements ToolboxAction
                                                                                                     uuid)
                 .asNode();
         final BusinessKnowledgeModel bkm = bkmNode.getContent().getDefinition();
-        final boolean isOnlyVisualChangeAllowed = false; //TODO {manstis} Read from BKM
+        final boolean isOnlyVisualChangeAllowed = bkm.isAllowOnlyVisualChange();
         editExpressionEvent.fire(new EditExpressionEvent(sessionManager.getCurrentSession(),
                                                          uuid,
                                                          bkm.asHasExpression(),

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDecisionToolboxAction.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/canvas/controls/toolbox/DMNEditDecisionToolboxAction.java
@@ -81,7 +81,7 @@ public class DMNEditDecisionToolboxAction implements ToolboxAction<AbstractCanva
                                                                                       uuid)
                 .asNode();
         final Decision decision = decisionNode.getContent().getDefinition();
-        final boolean isOnlyVisualChangeAllowed = false; //TODO {manstis} Read from Decision
+        final boolean isOnlyVisualChangeAllowed = decision.isAllowOnlyVisualChange();
         editExpressionEvent.fire(new EditExpressionEvent(sessionManager.getCurrentSession(),
                                                          uuid,
                                                          decision,

--- a/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/factories/DecisionNavigatorNestedItemFactory.java
+++ b/kie-wb-common-dmn/kie-wb-common-dmn-client/src/main/java/org/kie/workbench/common/dmn/client/decision/factories/DecisionNavigatorNestedItemFactory.java
@@ -29,6 +29,7 @@ import org.kie.workbench.common.dmn.api.definition.HasExpression;
 import org.kie.workbench.common.dmn.api.definition.HasName;
 import org.kie.workbench.common.dmn.api.definition.v1_1.BusinessKnowledgeModel;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Context;
+import org.kie.workbench.common.dmn.api.definition.v1_1.DRGElement;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Decision;
 import org.kie.workbench.common.dmn.api.definition.v1_1.DecisionTable;
 import org.kie.workbench.common.dmn.api.definition.v1_1.Expression;
@@ -134,9 +135,16 @@ public class DecisionNavigatorNestedItemFactory {
         final Object definition = getDefinition(node);
         final Optional<HasName> hasName = Optional.of((HasName) definition);
         final HasExpression hasExpression = getHasExpression(node);
-        final boolean isOnlyVisualChangeAllowed = false; //TODO {manstis} Read from the definition
+        final boolean isOnlyVisualChangeAllowed = isOnlyVisualChangeAllowed(definition);
 
         return new EditExpressionEvent(currentSession, node.getUUID(), hasExpression, hasName, isOnlyVisualChangeAllowed);
+    }
+
+    private boolean isOnlyVisualChangeAllowed(final Object definition) {
+        if (definition instanceof DRGElement) {
+            return ((DRGElement) definition).isAllowOnlyVisualChange();
+        }
+        return false;
     }
 
     String getUUID(final Node<View, Edge> node) {


### PR DESCRIPTION
@danielzhe In this PR I'm extracting some logic from the `unmarshall` method to smaller and easy to test methods.

I've tried to make the extraction by using streams (to make the logic more readable and step-by-step guided).

Another improvement introduced by this PR is the mechanism to check imported elements. I'm replacing the one based on `.contains(":")` in favor of the use of the List of imported elements.
